### PR TITLE
Add raster pyramid mark

### DIFF
--- a/packages/plot/src/index.js
+++ b/packages/plot/src/index.js
@@ -14,6 +14,7 @@ export { Grid2DMark } from './marks/Grid2DMark.js';
 export { HexbinMark } from './marks/HexbinMark.js';
 export { RasterMark, HeatmapMark } from './marks/RasterMark.js';
 export { RasterTileMark } from './marks/RasterTileMark.js';
+export { RasterPyramidMark } from './marks/RasterPyramidMark.js';
 export { RegressionMark } from './marks/RegressionMark.js';
 
 // interactors

--- a/packages/plot/src/marks/RasterPyramidMark.js
+++ b/packages/plot/src/marks/RasterPyramidMark.js
@@ -1,0 +1,54 @@
+import { RasterTileMark } from './RasterTileMark.js';
+import { extentX, extentY } from './util/extent.js';
+
+export class RasterPyramidMark extends RasterTileMark {
+  constructor(source, options = {}) {
+    const { levels = [1, 2, 4, 8], pixelSize = 1, ...rest } = options;
+    super(source, { pixelSize, ...rest });
+    this.basePixelSize = pixelSize;
+    this.levels = levels;
+    this._levelIndex = 0;
+    this.pixelSizeCurrent = pixelSize;
+    this._initExtent = null;
+  }
+
+  setPlot(plot, index) {
+    super.setPlot(plot, index);
+    // store the full data extent for zoom calculations
+    const filter = [];
+    const [x0, x1] = extentX(this, filter);
+    const [y0, y1] = extentY(this, filter);
+    this._initExtent = [[x0, x1], [y0, y1]];
+  }
+
+  currentLevel(xspan, yspan) {
+    const [ [x0, x1], [y0, y1] ] = this._initExtent || [[0,1],[0,1]];
+    const fullX = x1 - x0;
+    const fullY = y1 - y0;
+    const zoom = Math.max(fullX / xspan, fullY / yspan);
+    let level = 0;
+    for (let i = 0; i < this.levels.length; ++i) {
+      if (zoom >= this.levels[i]) level = i;
+    }
+    return level;
+  }
+
+  async requestTiles() {
+    const [x0, x1] = extentX(this, this._filter);
+    const [y0, y1] = extentY(this, this._filter);
+    const level = this.currentLevel(x1 - x0, y1 - y0);
+    this._levelIndex = level;
+    this.pixelSizeCurrent = this.basePixelSize / this.levels[level];
+    this.pixelSize = this.pixelSizeCurrent;
+    return super.requestTiles();
+  }
+
+  binDimensions() {
+    const ps = this.pixelSizeCurrent || this.basePixelSize;
+    const { plot, width, height } = this;
+    return [
+      width ?? Math.round(plot.innerWidth() / ps),
+      height ?? Math.round(plot.innerHeight() / ps)
+    ];
+  }
+}

--- a/packages/spec/src/spec/PlotMark.ts
+++ b/packages/spec/src/spec/PlotMark.ts
@@ -16,7 +16,7 @@ import { Hexgrid } from './marks/Hexgrid.js';
 import { Image } from './marks/Image.js';
 import { Line, LineX, LineY } from './marks/Line.js';
 import { Link } from './marks/Link.js';
-import { Heatmap, Raster, RasterTile } from './marks/Raster.js';
+import { Heatmap, Raster, RasterTile, RasterPyramid } from './marks/Raster.js';
 import { Rect, RectX, RectY } from './marks/Rect.js';
 import { RegressionY } from './marks/Regression.js';
 import { RuleX, RuleY } from './marks/Rule.js';
@@ -45,7 +45,7 @@ export type PlotMark =
   | Image
   | Line | LineX | LineY
   | Link
-  | Raster | Heatmap | RasterTile
+  | Raster | Heatmap | RasterTile | RasterPyramid
   | Rect | RectX | RectY
   | RegressionY
   | RuleX | RuleY

--- a/packages/spec/src/spec/marks/Raster.ts
+++ b/packages/spec/src/spec/marks/Raster.ts
@@ -143,3 +143,18 @@ export interface RasterTile extends MarkData, RasterOptions {
    */
   origin?: [number, number] | ParamRef;
 }
+
+/** The rasterPyramid mark. */
+export interface RasterPyramid extends MarkData, RasterOptions {
+  /**
+   * A raster mark that automatically switches between multiple
+   * precomputed resolution levels during zooming and panning.
+   */
+  mark: 'rasterPyramid';
+
+  /**
+   * Zoom level scale factors used to determine raster resolutions.
+   * Larger values correspond to finer detail.
+   */
+  levels?: number[] | ParamRef;
+}

--- a/packages/vgplot/src/api.js
+++ b/packages/vgplot/src/api.js
@@ -318,7 +318,7 @@ export {
   tickX, tickY,
   ruleX, ruleY,
   density, densityX, densityY, denseLine,
-  raster, rasterTile, heatmap,
+  raster, rasterTile, rasterPyramid, heatmap,
   contour,
   hexbin, hexgrid,
   regressionY,

--- a/packages/vgplot/src/plot/marks.js
+++ b/packages/vgplot/src/plot/marks.js
@@ -11,6 +11,7 @@ import {
   HexbinMark,
   RasterMark,
   RasterTileMark,
+  RasterPyramidMark,
   RegressionMark,
 } from '@uwdata/mosaic-plot';
 
@@ -97,6 +98,7 @@ export const contour = (...args) => implicitType(ContourMark, ...args);
 export const heatmap = (...args) => implicitType(HeatmapMark, ...args);
 export const raster = (...args) => implicitType(RasterMark, ...args);
 export const rasterTile = (...args) => implicitType(RasterTileMark, ...args);
+export const rasterPyramid = (...args) => implicitType(RasterPyramidMark, ...args);
 
 export const hexbin = (...args) => implicitType(HexbinMark, ...args);
 export const hexgrid = (...args) => mark('hexgrid', ...args);


### PR DESCRIPTION
## Summary
- add `RasterPyramidMark` for zoom-level rasters
- export new mark from plot, vgplot and API
- extend TypeScript specs with `rasterPyramid` definition

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c88af0408321b957070013279e2b