### PR TITLE
Update terser import in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 
 export default [
   {


### PR DESCRIPTION
## Summary
- import terser from `@rollup/plugin-terser`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685121ce47048321bb85e59726324bfa