### PR TITLE
Fix raster tile numRows and add test

### DIFF
--- a/packages/plot/src/marks/RasterTileMark.js
+++ b/packages/plot/src/marks/RasterTileMark.js
@@ -158,8 +158,12 @@ export class RasterTileMark extends Grid2DMark {
     // wait for tile queries to complete, then update
     const tiles = await Promise.all(queries);
     const density = processTiles(m, n, xx, yy, coords, tiles);
+    // numRows should reflect the number of raster groups. Currently
+    // raster tiles do not support grouping, so we default to one group.
+    // If grouping is added in the future, update this logic to use the
+    // actual group count of the returned tiles.
     this.grids0 = {
-      numRows: density.length,
+      numRows: 1,
       columns: { density: [density] }
     };
     this.convolve().update();

--- a/packages/plot/test/raster-tile-mark.test.js
+++ b/packages/plot/test/raster-tile-mark.test.js
@@ -1,0 +1,55 @@
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { RasterTileMark } from '../src/marks/RasterTileMark.js';
+import { Plot } from '../src/plot.js';
+import { coordinator, Coordinator } from '@uwdata/mosaic-core';
+
+function fakeTable() {
+  return {
+    numRows: 0,
+    getChild() {
+      return { toArray: () => [] };
+    }
+  };
+}
+
+describe('RasterTileMark', () => {
+  let dom;
+  let prev;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><body></body>`, { pretendToBeVisual: true });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.requestAnimationFrame = window.requestAnimationFrame;
+
+    prev = coordinator();
+    coordinator({
+      query: async () => fakeTable(),
+      prefetch: async () => null,
+      cancel: () => {}
+    });
+  });
+
+  afterEach(() => {
+    delete globalThis.requestAnimationFrame;
+    delete globalThis.document;
+    delete globalThis.window;
+    coordinator(prev);
+  });
+
+  it('returns a single density grid', async () => {
+    const plot = new Plot();
+    plot.setAttribute('xDomain', [0, 1]);
+    plot.setAttribute('yDomain', [0, 1]);
+
+    const mark = new RasterTileMark({ table: 't' }, { x: 'x', y: 'y' });
+    mark.convolve = () => mark; // skip rasterization
+    mark.update = () => {}; // skip plot update
+
+    plot.addMark(mark);
+    await mark.requestTiles();
+
+    expect(mark.grids0.numRows).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- fix raster tile grid row count
- test RasterTileMark grid count

## Testing
- `npm test --silent` *(fails: ENOENT mosaic-schema.json; arrow extension not installed, test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68512f9ca4c88321b3b091d655e4ea19