### PR TITLE
Fix raster tile tests and caching

### DIFF
--- a/packages/plot/src/marks/RasterTileMark.js
+++ b/packages/plot/src/marks/RasterTileMark.js
@@ -12,6 +12,8 @@ export class RasterTileMark extends Grid2DMark {
     const { origin = [0, 0], dim = 'xy', ...markOptions } = options;
     super('image', source, markOptions);
     this.image = null;
+    this.tileCache = new Map();
+    this._precomputed = false;
 
     // TODO: make part of data source instead of options?
     this.origin = origin;
@@ -98,10 +100,50 @@ export class RasterTileMark extends Grid2DMark {
     }
   }
 
+  async precomputeAllTiles() {
+    if (this._precomputed) return;
+
+    const mc = coordinator();
+    const { tileX, tileY, origin: [tx, ty] } = this;
+    this.bins = this.binDimensions();
+
+    const [x0, x1] = extentX(this, []);
+    const [y0, y1] = extentY(this, []);
+
+    const xspan = x1 - x0;
+    const yspan = y1 - y0;
+
+    const tileExtent = (i, j) => [
+      [tx + i * xspan, tx + (i + 1) * xspan],
+      [ty + j * yspan, ty + (j + 1) * yspan]
+    ];
+
+    const i0 = Math.floor((x0 - tx) / xspan);
+    const i1 = tileX ? tileFloor((x1 - tx) / xspan) : i0;
+    const j0 = Math.floor((y0 - ty) / yspan);
+    const j1 = tileY ? tileFloor((y1 - ty) / yspan) : j0;
+
+    const coords = [];
+    for (let i = i0; i <= i1; ++i) {
+      for (let j = j0; j <= j1; ++j) {
+        coords.push([i, j]);
+      }
+    }
+
+    const queries = coords.map(([i, j]) => mc.query(this.tileQuery(tileExtent(i, j))));
+    const tiles = await Promise.all(queries);
+    coords.forEach((c, idx) => {
+      this.tileCache.set(c.join(','), tiles[idx]);
+    });
+    this._precomputed = true;
+  }
+
   async requestTiles() {
     // get coordinator, cancel prior prefetch queries
     const mc = coordinator();
     if (this.prefetch) mc.cancel(this.prefetch);
+
+    await this.precomputeAllTiles();
 
     // get view extent info
     const { pad, tileX, tileY, origin: [tx, ty] } = this;
@@ -131,9 +173,19 @@ export class RasterTileMark extends Grid2DMark {
         coords.push([i, j]);
       }
     }
-    const queries = coords.map(
-      ([i, j]) => mc.query(this.tileQuery(tileExtent(i, j)))
-    );
+    const tilePromises = coords.map(([i, j]) => {
+      const key = `${i},${j}`;
+      if (this.tileCache.has(key)) {
+        return this.tileCache.get(key);
+      } else {
+        const q = mc.query(this.tileQuery(tileExtent(i, j))).then(res => {
+          this.tileCache.set(key, res);
+          return res;
+        });
+        this.tileCache.set(key, q);
+        return q;
+      }
+    });
 
     // prefetch tiles along periphery of current tiles
     const prefetchCoords = [];
@@ -156,10 +208,14 @@ export class RasterTileMark extends Grid2DMark {
     );
 
     // wait for tile queries to complete, then update
-    const tiles = await Promise.all(queries);
+    const tiles = await Promise.all(tilePromises);
     const density = processTiles(m, n, xx, yy, coords, tiles);
+    // numRows should reflect the number of raster groups. Currently
+    // raster tiles do not support grouping, so we default to one group.
+    // If grouping is added in the future, update this logic to use the
+    // actual group count of the returned tiles.
     this.grids0 = {
-      numRows: density.length,
+      numRows: 1,
       columns: { density: [density] }
     };
     this.convolve().update();

--- a/packages/plot/test/raster-tile-mark.test.js
+++ b/packages/plot/test/raster-tile-mark.test.js
@@ -1,0 +1,61 @@
+// Tests for raster tile mark
+
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { RasterTileMark } from '../src/marks/RasterTileMark.js';
+import { Plot } from '../src/plot.js';
+import { coordinator } from '@uwdata/mosaic-core';
+
+function fakeTable() {
+  return {
+    numRows: 0,
+    getChild() {
+      return { toArray: () => [] };
+    }
+  };
+}
+
+describe('RasterTileMark', () => {
+  let dom;
+  let prev;
+  let callCount;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><body></body>`, { pretendToBeVisual: true });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.requestAnimationFrame = window.requestAnimationFrame;
+
+    prev = coordinator();
+    callCount = 0;
+    coordinator({
+      query: async () => { callCount++; return fakeTable(); },
+      prefetch: async () => null,
+      cancel: () => {}
+    });
+  });
+
+  afterEach(() => {
+    delete globalThis.requestAnimationFrame;
+    delete globalThis.document;
+    delete globalThis.window;
+    coordinator(prev);
+  });
+
+  it('returns a single density grid', async () => {
+    const plot = new Plot();
+    plot.setAttribute('xDomain', [0, 1]);
+    plot.setAttribute('yDomain', [0, 1]);
+
+    const mark = new RasterTileMark({ table: 't' }, { x: 'x', y: 'y' });
+    mark.convolve = () => mark; // skip rasterization
+    mark.update = () => {}; // skip plot update
+
+    plot.addMark(mark);
+    await mark.requestTiles();
+
+    expect(mark.grids0.numRows).toBe(1);
+    expect(callCount).toBeGreaterThan(0);
+    expect(mark.tileCache.size).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- cache raster tiles and precompute
- set `numRows` correctly for raster tiles
- test raster tile grid count
- resolve merge conflict in test file

## Testing
- `npx lerna run lint` *(fails: Running target lint for 8 projects failed)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512f9ca4c88321b3b091d655e4ea19