### PR TITLE
Add deck.gl scatterplot mark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -614,6 +614,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -785,6 +794,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@deck.gl/core": {
+      "version": "8.9.36",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.36.tgz",
+      "integrity": "sha512-mkIv4/fY1jE+iehqSJzUQi75l9cgfx2ZBa1s1AifgLu0TCkCZgRgISV3UnDBECDCmTZ9Cqk+oKq3OGay3Bz1RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/core": "^3.4.13",
+        "@loaders.gl/images": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/core": "^8.5.21",
+        "@luma.gl/webgl": "^8.5.21",
+        "@math.gl/core": "^3.6.2",
+        "@math.gl/sun": "^3.6.2",
+        "@math.gl/web-mercator": "^3.6.2",
+        "@probe.gl/env": "^3.5.0",
+        "@probe.gl/log": "^3.5.0",
+        "@probe.gl/stats": "^3.5.0",
+        "gl-matrix": "^3.0.0",
+        "math.gl": "^3.6.2",
+        "mjolnir.js": "^2.7.0"
+      }
+    },
+    "node_modules/@deck.gl/layers": {
+      "version": "8.9.36",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.36.tgz",
+      "integrity": "sha512-sr/QKELXZ4W0ZHb12QC2+EV1bZJOM6cU6kAfOJD5jOVixOcyccr+FnPPGn39VK9cl/VFY0S339ZPs9reyhDFVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/images": "^3.4.13",
+        "@loaders.gl/schema": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@math.gl/core": "^3.6.2",
+        "@math.gl/polygon": "^3.6.2",
+        "@math.gl/web-mercator": "^3.6.2",
+        "earcut": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@loaders.gl/core": "^3.4.13",
+        "@luma.gl/core": "^8.0.0"
       }
     },
     "node_modules/@docsearch/css": {
@@ -1992,6 +2046,56 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@loaders.gl/core": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.15.tgz",
+      "integrity": "sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/log": "^3.5.0"
+      }
+    },
+    "node_modules/@loaders.gl/images": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.15.tgz",
+      "integrity": "sha512-QpjYhEetHabY/z9mWZYJXZZp4XJAxa38f9Ii/DjPlnJErepzY5GLBUTDHMu4oZ6n99gGImtuGFicDnFV6mb60g==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.4.15"
+      }
+    },
+    "node_modules/@loaders.gl/loader-utils": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz",
+      "integrity": "sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/stats": "^3.5.0"
+      }
+    },
+    "node_modules/@loaders.gl/schema": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.15.tgz",
+      "integrity": "sha512-8oRtstz0IsqES7eZd2jQbmCnmExCMtL8T6jWd1+BfmnuyZnQ0B6TNccy++NHtffHdYuzEoQgSELwcdmhSApYew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
+      }
+    },
+    "node_modules/@loaders.gl/worker-utils": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz",
+      "integrity": "sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2013,6 +2117,79 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@luma.gl/constants": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz",
+      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA==",
+      "license": "MIT"
+    },
+    "node_modules/@luma.gl/core": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.21.tgz",
+      "integrity": "sha512-11jQJQEMoR/IN2oIsd4zFxiQJk6FE+xgVIMUcsCTBuzafTtQZ8Po9df8mt+MVewpDyBlTVs6g8nxHRH4np1ukA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/engine": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
+        "@luma.gl/shadertools": "8.5.21",
+        "@luma.gl/webgl": "8.5.21"
+      }
+    },
+    "node_modules/@luma.gl/engine": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.21.tgz",
+      "integrity": "sha512-IG3WQSKXFNUEs8QG7ZjHtGiOtsakUu+BAxtJ6997A6/F06yynZ44tPe5NU70jG9Yfu3kV0LykPZg7hO3vXZDiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
+        "@luma.gl/shadertools": "8.5.21",
+        "@luma.gl/webgl": "8.5.21",
+        "@math.gl/core": "^3.5.0",
+        "@probe.gl/env": "^3.5.0",
+        "@probe.gl/stats": "^3.5.0",
+        "@types/offscreencanvas": "^2019.7.0"
+      }
+    },
+    "node_modules/@luma.gl/gltools": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.21.tgz",
+      "integrity": "sha512-6qZ0LaT2Mxa4AJT5F44TFoaziokYiHUwO45vnM/NYUOIu9xevcmS6VtToawytMEACGL6PDeDyVqP3Y80SDzq5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.21",
+        "@probe.gl/env": "^3.5.0",
+        "@probe.gl/log": "^3.5.0",
+        "@types/offscreencanvas": "^2019.7.0"
+      }
+    },
+    "node_modules/@luma.gl/shadertools": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.21.tgz",
+      "integrity": "sha512-WQah7yFDJ8cNCLPYpIm3r0wSlXLvjoA279fcknmATvvkW3/i8PcCJ/nYEBJO3hHEwwMQxD16+YZu/uwGiifLMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@math.gl/core": "^3.5.0"
+      }
+    },
+    "node_modules/@luma.gl/webgl": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.21.tgz",
+      "integrity": "sha512-ZVLO4W5UuaOlzZIwmFWhnmZ1gYoU97a+heMqxLrSSmCUAsSu3ZETUex9gOmzdM1WWxcdWaa3M68rvKCNEgwz0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
+        "@probe.gl/env": "^3.5.0",
+        "@probe.gl/stats": "^3.5.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -2120,6 +2297,57 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@math.gl/core": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/types": "3.6.3",
+        "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/@math.gl/polygon": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
+      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "3.6.3"
+      }
+    },
+    "node_modules/@math.gl/sun": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/sun/-/sun-3.6.3.tgz",
+      "integrity": "sha512-mrx6CGYYeTNSQttvcw0KVUy+35YDmnjMqpO/o0t06Vcghrt0HNruB/ScRgUSbJrgkbOg1Vcqm23HBd++clzQzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0"
+      }
+    },
+    "node_modules/@math.gl/types": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
+      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
+      "license": "MIT"
+    },
+    "node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3022,6 +3250,34 @@
         "node": ">=14"
       }
     },
+    "node_modules/@probe.gl/env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-3.6.0.tgz",
+      "integrity": "sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@probe.gl/log": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz",
+      "integrity": "sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/env": "3.6.0"
+      }
+    },
+    "node_modules/@probe.gl/stats": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
+      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz",
@@ -3697,6 +3953,12 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -3776,6 +4038,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -7092,6 +7360,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -8396,6 +8670,12 @@
         "ini": "^1.3.2"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -8515,6 +8795,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -10076,6 +10365,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/math.gl": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.6.3.tgz",
+      "integrity": "sha512-Yq9CyECvSDox9+5ETi2+x1bGTY5WvGUGL3rJfC4KPoCZAM51MGfrCm6rIn4yOJUVfMPs2a5RwMD+yGS/n1g3gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "3.6.3"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
@@ -10684,6 +10982,20 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mjolnir.js": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.7.3.tgz",
+      "integrity": "sha512-Z5z/+FzZqOSO3juSVKV3zcm4R2eAlWwlKMcqHmyFEJAaLILNcDKnIbnb4/kbcGyIuhtdWrzu8WOIR7uM6I34aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.41",
+        "hammerjs": "^2.0.8"
+      },
+      "engines": {
+        "node": ">= 4",
+        "npm": ">= 3"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -16287,6 +16599,8 @@
       "version": "0.17.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@deck.gl/core": "^8.9.0",
+        "@deck.gl/layers": "^8.9.0",
         "@observablehq/plot": "^0.6.17",
         "@uwdata/mosaic-core": "^0.17.0",
         "@uwdata/mosaic-sql": "^0.17.0",

--- a/packages/vgplot/plot/package.json
+++ b/packages/vgplot/plot/package.json
@@ -36,6 +36,8 @@
     "@observablehq/plot": "^0.6.17",
     "@uwdata/mosaic-core": "^0.17.0",
     "@uwdata/mosaic-sql": "^0.17.0",
-    "d3": "^7.9.0"
+    "d3": "^7.9.0",
+    "@deck.gl/core": "^8.9.0",
+    "@deck.gl/layers": "^8.9.0"
   }
 }

--- a/packages/vgplot/plot/src/DeckGLPlot.js
+++ b/packages/vgplot/plot/src/DeckGLPlot.js
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import { Plot } from './plot.js';
+import { DeckGLRenderer } from './DeckGLRenderer.js';
+
+export class DeckGLPlot extends Plot {
+  constructor(marks = [], options = {}) {
+    super(null);
+    this.marks = marks;
+    this.renderer = null;
+    this.coordinateSystem = options.coordinateSystem || 'CARTESIAN';
+    this.options = options;
+  }
+
+  async render(coordinator, opts = {}) {
+    const { width = 600, height = 400 } = opts;
+    const container = this.element;
+    container.style.width = `${width}px`;
+    container.style.height = `${height}px`;
+    container.style.position = 'relative';
+    this.renderer = new DeckGLRenderer(container, {
+      coordinateSystem: this.coordinateSystem
+    });
+    this.renderer.initialize();
+
+    for (const mark of this.marks) {
+      if (mark.type === 'deckgl-scatterplot') {
+        await this.renderDeckMark(mark, coordinator);
+      }
+    }
+    return;
+  }
+
+  async renderDeckMark(mark, coordinator) {
+    const q = mark.query();
+    const data = await coordinator.query(q, { type: 'arrow' });
+    const spec = mark.plotSpecs();
+    let points;
+    if (data && typeof data.toArray === 'function') {
+      points = mark.convertArrowToPoints(data);
+    } else {
+      points = Array.isArray(data) ? data : [];
+    }
+    this.renderer.addLayer(spec, points);
+    mark.addEventListener('data', e => {
+      const upd = mark.convertArrowToPoints(e.detail);
+      this.renderer.addLayer(spec, upd);
+    });
+  }
+
+  async update(mark) {
+    if (mark.type === 'deckgl-scatterplot' && mark.processedData) {
+      const spec = mark.plotSpecs();
+      this.renderer.addLayer(spec, mark.processedData);
+    }
+    return Promise.resolve();
+  }
+
+  destroy() {
+    if (this.renderer) {
+      this.renderer.destroy();
+      this.renderer = null;
+    }
+  }
+}

--- a/packages/vgplot/plot/src/DeckGLRenderer.js
+++ b/packages/vgplot/plot/src/DeckGLRenderer.js
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import { Deck } from '@deck.gl/core';
+import { ScatterplotLayer } from '@deck.gl/layers';
+import { OrbitView } from '@deck.gl/core';
+
+export class DeckGLRenderer {
+  constructor(container, options = {}) {
+    this.container = container;
+    this.deckInstance = null;
+    this.layers = [];
+    this.viewState = options.viewState || this.getDefaultViewState();
+    this.coordinateSystem = options.coordinateSystem || 'CARTESIAN';
+  }
+
+  initialize() {
+    const views = this.coordinateSystem === 'CARTESIAN'
+      ? [new OrbitView({})]
+      : [];
+
+    this.deckInstance = new Deck({
+      parent: this.container,
+      views,
+      initialViewState: this.viewState,
+      controller: true,
+      layers: this.layers
+    });
+    return this.deckInstance;
+  }
+
+  addLayer(markSpec, data) {
+    const cfg = markSpec.props;
+    let layer;
+    switch (markSpec.layerType) {
+      case 'ScatterplotLayer':
+        layer = new ScatterplotLayer({
+          ...cfg,
+          data: data || cfg.data
+        });
+        break;
+      default:
+        throw new Error(`Unsupported layer type: ${markSpec.layerType}`);
+    }
+    const idx = this.layers.findIndex(l => l.id === layer.id);
+    if (idx >= 0) this.layers[idx] = layer; else this.layers.push(layer);
+    this.updateLayers();
+    return layer;
+  }
+
+  updateLayers() {
+    if (this.deckInstance) {
+      this.deckInstance.setProps({ layers: [...this.layers] });
+    }
+  }
+
+  setViewState(v) {
+    this.viewState = v;
+    if (this.deckInstance) {
+      this.deckInstance.setProps({ initialViewState: v });
+    }
+  }
+
+  getDefaultViewState() {
+    return this.coordinateSystem === 'CARTESIAN'
+      ? { target: [0,0,0], zoom: 5, pitch: 0, bearing: 0 }
+      : { longitude: 0, latitude: 0, zoom: 2, pitch:0, bearing:0 };
+  }
+
+  destroy() {
+    if (this.deckInstance) {
+      this.deckInstance.finalize();
+      this.deckInstance = null;
+    }
+    this.layers = [];
+  }
+}

--- a/packages/vgplot/plot/src/index.js
+++ b/packages/vgplot/plot/src/index.js
@@ -15,6 +15,11 @@ export { HexbinMark } from './marks/HexbinMark.js';
 export { RasterMark, HeatmapMark } from './marks/RasterMark.js';
 export { RasterTileMark } from './marks/RasterTileMark.js';
 export { RegressionMark } from './marks/RegressionMark.js';
+export { DeckGLScatterplotMark } from './marks/DeckGLScatterplotMark.js';
+
+// deck.gl
+export { DeckGLRenderer } from './DeckGLRenderer.js';
+export { DeckGLPlot } from './DeckGLPlot.js';
 
 // interactors
 export { Highlight } from './interactors/Highlight.js';

--- a/packages/vgplot/plot/src/marks/DeckGLScatterplotMark.js
+++ b/packages/vgplot/plot/src/marks/DeckGLScatterplotMark.js
@@ -1,0 +1,100 @@
+// @ts-nocheck
+import { Mark } from './Mark.js';
+import { sql } from '@uwdata/mosaic-sql';
+
+export class DeckGLScatterplotMark extends Mark {
+  constructor(data, options = {}) {
+    super('deckgl-scatterplot', data, options);
+    this.coordinateSystem = options.coordinateSystem || 'CARTESIAN';
+    this.radiusScale = options.radiusScale ?? 1;
+    this.radiusMinPixels = options.radiusMinPixels ?? 1;
+    this.radiusMaxPixels = options.radiusMaxPixels ?? 100;
+    this.opacity = options.opacity ?? 0.8;
+  }
+
+  query(filter = []) {
+    const { channels, source } = this;
+    const x = channels.find(c => c.channel === 'x')?.field;
+    const y = channels.find(c => c.channel === 'y')?.field;
+    const color = channels.find(c => c.channel === 'color')?.field;
+    const radius = channels.find(c => c.channel === 'radius')?.field
+      || channels.find(c => c.channel === 'size')?.field;
+
+    if (!x || !y) throw new Error('DeckGL scatterplot requires x and y channels');
+
+    const columns = [
+      sql`ST_Point2D(${x}, ${y}) AS geom`,
+      sql`${x} AS x`,
+      sql`${y} AS y`
+    ];
+    if (color) columns.push(sql`${color} AS color`);
+    if (radius) columns.push(sql`${radius} AS radius`);
+
+    for (const { channel, field } of channels) {
+      if (!['x','y','color','radius','size'].includes(channel) && field) {
+        columns.push(sql`${field} AS ${channel}`);
+      }
+    }
+
+    const query = sql`SELECT ${columns} FROM ${source.table}`;
+    if (filter.length) query.where(...filter);
+    return query;
+  }
+
+  plotSpecs() {
+    return {
+      type: 'deckgl-layer',
+      layerType: 'ScatterplotLayer',
+      props: {
+        id: `deckgl-scatterplot-${this.id || Math.random()}`,
+        coordinateSystem: this.coordinateSystem,
+        radiusScale: this.radiusScale,
+        radiusMinPixels: this.radiusMinPixels,
+        radiusMaxPixels: this.radiusMaxPixels,
+        opacity: this.opacity,
+        pickable: true,
+        getPosition: this.getPositionAccessor(),
+        getFillColor: this.getColorAccessor(),
+        getRadius: this.getRadiusAccessor(),
+        data: []
+      }
+    };
+  }
+
+  getPositionAccessor() {
+    return d => [d.x, d.y];
+  }
+
+  getColorAccessor() {
+    return d => d.color ?? [255,140,0,255];
+  }
+
+  getRadiusAccessor() {
+    return d => d.radius ?? 5;
+  }
+
+  async update(data) {
+    await super.update();
+    if (data && typeof data.toArray === 'function') {
+      this.processedData = this.convertArrowToPoints(data);
+    } else if (Array.isArray(data)) {
+      this.processedData = data;
+    }
+    this.requestUpdate();
+  }
+
+  convertArrowToPoints(table) {
+    const points = [];
+    const n = table.numRows;
+    for (let i=0; i<n; ++i) {
+      const p = { x: table.getChild('x')?.get(i) ?? 0,
+                  y: table.getChild('y')?.get(i) ?? 0 };
+      const c = table.getChild('color');
+      if (c) p.color = c.get(i);
+      const r = table.getChild('radius');
+      if (r) p.radius = r.get(i);
+      points.push(p);
+    }
+    return points;
+  }
+}

--- a/packages/vgplot/spec/src/spec/PlotMark.ts
+++ b/packages/vgplot/spec/src/spec/PlotMark.ts
@@ -14,6 +14,7 @@ import { Geo, Graticule, Sphere } from './marks/Geo.js';
 import { Hexbin } from './marks/Hexbin.js';
 import { Hexgrid } from './marks/Hexgrid.js';
 import { Image } from './marks/Image.js';
+import { DeckGLScatterplot } from './marks/DeckGLScatterplot.js';
 import { Line, LineX, LineY } from './marks/Line.js';
 import { Link } from './marks/Link.js';
 import { Heatmap, Raster, RasterTile } from './marks/Raster.js';
@@ -52,4 +53,5 @@ export type PlotMark =
   | Text | TextX | TextY
   | TickX | TickY
   | Vector | VectorX | VectorY | Spike
-  | WaffleX | WaffleY;
+  | WaffleX | WaffleY
+  | DeckGLScatterplot;

--- a/packages/vgplot/spec/src/spec/marks/DeckGLScatterplot.ts
+++ b/packages/vgplot/spec/src/spec/marks/DeckGLScatterplot.ts
@@ -1,0 +1,20 @@
+import { ChannelValueSpec, MarkData, MarkOptions } from './Marks.js';
+
+export interface DeckGLScatterplotOptions extends MarkOptions {
+  x?: ChannelValueSpec;
+  y?: ChannelValueSpec;
+  color?: ChannelValueSpec;
+  radius?: ChannelValueSpec;
+  size?: ChannelValueSpec;
+  opacity?: number;
+  coordinateSystem?: 'CARTESIAN' | 'LNGLAT';
+  radiusScale?: number;
+  radiusMinPixels?: number;
+  radiusMaxPixels?: number;
+  pickable?: boolean;
+  layerProps?: Record<string, any>;
+}
+
+export interface DeckGLScatterplot extends MarkData, DeckGLScatterplotOptions {
+  mark: 'deckgl-scatterplot';
+}

--- a/packages/vgplot/vgplot/src/api.js
+++ b/packages/vgplot/vgplot/src/api.js
@@ -10,6 +10,12 @@ export {
 } from '@uwdata/mosaic-plot';
 
 export {
+  DeckGLScatterplotMark,
+  DeckGLPlot
+} from '@uwdata/mosaic-plot';
+export { initializeDeckGL } from './deckgl.js';
+
+export {
   Query,
   sql,
   column,
@@ -327,6 +333,7 @@ export {
   vector, vectorX, vectorY, spike,
   voronoi, voronoiMesh, delaunayLink, delaunayMesh, hull,
   arrow, link,
+  deckglScatterplot,
   frame,
   axisX, axisY, axisFx, axisFy,
   gridX, gridY, gridFx, gridFy,

--- a/packages/vgplot/vgplot/src/deckgl.js
+++ b/packages/vgplot/vgplot/src/deckgl.js
@@ -1,0 +1,7 @@
+// @ts-nocheck
+export function initializeDeckGL() {
+  if (typeof deck === 'undefined') {
+    throw new Error('deck.gl not loaded. Please include deck.gl in your HTML.');
+  }
+  return true;
+}

--- a/packages/vgplot/vgplot/src/plot/marks.js
+++ b/packages/vgplot/vgplot/src/plot/marks.js
@@ -12,6 +12,7 @@ import {
   RasterMark,
   RasterTileMark,
   RegressionMark,
+  DeckGLScatterplotMark,
 } from '@uwdata/mosaic-plot';
 
 const decorators = new Set([
@@ -29,6 +30,8 @@ function mark(type, data, channels = {}) {
   }
   const MarkClass = type.startsWith('area') || type.startsWith('line')
     ? ConnectedMark
+    : type === 'deckgl-scatterplot'
+    ? DeckGLScatterplotMark
     : Mark;
 
   return explicitType(MarkClass, type, data, channels);
@@ -114,6 +117,7 @@ export const hull = (...args) => mark('hull', ...args);
 
 export const arrow = (...args) => mark('arrow', ...args);
 export const link = (...args) => mark('link', ...args);
+export const deckglScatterplot = (...args) => mark('deckgl-scatterplot', ...args);
 
 export const frame = (...args) => mark('frame', ...args);
 


### PR DESCRIPTION
## Summary
- implement `DeckGLScatterplotMark` mark and supporting renderer
- add `DeckGLPlot` for deck.gl-based rendering
- expose deck.gl helpers and mark creation in API
- define `DeckGLScatterplot` spec interface
- update PlotMark union and exports
- add deck.gl dependencies

## Testing
- `npm install` *(installs dependencies)*
- `npm test` *(fails: DuckDB arrow extension missing, many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686b8ea779b88321b4a9f043b3aaf0e7